### PR TITLE
fix parser+typecheck bug

### DIFF
--- a/src/menhir_parser.mly
+++ b/src/menhir_parser.mly
@@ -660,7 +660,7 @@ let expr_aux ==
     let bt = match pt, rt with
     | [], [] -> bt
     | pt, rt ->
-      let pt = List.rev_map (fun t -> None, t) pt in
+      let pt = List.map (fun t -> None, t) pt in
       let raw = pt, rt in
       begin match bt with
       | Some (Arg.Bt_ind type_use) -> Some (bt_raw (Some type_use) raw)

--- a/src/typecheck.ml
+++ b/src/typecheck.ml
@@ -284,9 +284,6 @@ let rec typecheck_instr (env : env) (stack : stack) (instr : instr) :
     let t = Env.global_get i env in
     Stack.pop [ typ_of_val_type t ] stack
   | If_else (_id, block_type, e1, e2) ->
-    let block_type =
-      Option.map (fun (pt, rt) -> (List.rev pt, rt)) block_type
-    in
     let* stack = Stack.pop [ i32 ] stack in
     let* stack_e1 = typecheck_expr env e1 ~is_loop:false block_type ~stack in
     let* _stack_e2 = typecheck_expr env e2 ~is_loop:false block_type ~stack in


### PR DESCRIPTION
This one is funny.

I had type-checking error while fuzzing but not when running the `owi` binary directly. This was because the type-checker was incorrect but going through the parser was hiding the bug.

The parser bug is one incorrect fix that I made and that looked OK at the time because of the other bug fixed recently.